### PR TITLE
Support item with subtasks that have been moved from backlog to someday.

### DIFF
--- a/sprintly.py
+++ b/sprintly.py
@@ -370,6 +370,8 @@ through the template configured in the Git config at sprintly.template.
 
         for product in products:
             for item in product['items']:
+                if item['status'] == 'someday':
+                    continue
                 if not product['id'] in statusTree[item['status']]:
                     statusTree[item['status']][product['id']] = []
                     itemCount += 1


### PR DESCRIPTION
This bug was inherited from the original code. A PR was provided there,
but not merged. This is a port of the original patch.

Reference: https://github.com/sprintly/Sprintly-GitHub/pull/22

I confirmed the issue affected this fork:

```
mark$ sprintly --all
Fatal error
Traceback (most recent call last):
  File "/usr/local/bin/sprintly", line 5, in <module>
  pkg_resources.run_script('sprintly-github==3.0.0', 'sprintly')
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line
  528, in run_script
  self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py",
  line 1394, in run_script
  execfile(script_filename, namespace, namespace)
  File
  "/usr/local/lib/python2.7/dist-packages/sprintly_github-3.0.0-py2.7.egg/EGG-INFO/scripts/sprintly",
  line 7, in <module>
  sprintlyTool.run(sprintlyTool.getOptions())
  File
  "/usr/local/lib/python2.7/dist-packages/sprintly_github-3.0.0-py2.7.egg/sprintly.py",
  line 168, in run
  self.listSprintlyItems(options)
  File
  "/usr/local/lib/python2.7/dist-packages/sprintly_github-3.0.0-py2.7.egg/sprintly.py",
  line 342, in listSprintlyItems
  self.printList(products,
      options.assignee)
  File
  "/usr/local/lib/python2.7/dist-packages/sprintly_github-3.0.0-py2.7.egg/sprintly.py",
  line 373, in printList
  if not product['id'] in
  statusTree[item['status']]:
  KeyError: u'someday'
```

After this patch was applied, `sprintly -all` works as expected with the
same Sprint.ly data.
